### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/templates/bootstrap/build/bootstrap.json
+++ b/templates/bootstrap/build/bootstrap.json
@@ -47,7 +47,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60
       }
     },

--- a/templates/bucket/build/bucket.json
+++ b/templates/bucket/build/bucket.json
@@ -14,7 +14,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60
       }
     },
@@ -32,7 +32,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60
       }
     },
@@ -50,7 +50,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60
       }
     },

--- a/templates/glue_dev_endpoint/build/glue_dev_endpoint.json
+++ b/templates/glue_dev_endpoint/build/glue_dev_endpoint.json
@@ -58,7 +58,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60
       }
     },
@@ -84,7 +84,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60
       }
     },
@@ -110,7 +110,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60
       }
     },

--- a/templates/messages/build/messages.json
+++ b/templates/messages/build/messages.json
@@ -52,7 +52,7 @@
         "Role": {
           "Ref": "APILambdaRoleArn"
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Layers": [
           {
             "Ref": "UtilLambdaLayer"
@@ -88,7 +88,7 @@
         "Role": {
           "Ref": "APILambdaRoleArn"
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Layers": [
           {
             "Ref": "UtilLambdaLayer"
@@ -124,7 +124,7 @@
         "Role": {
           "Ref": "APILambdaRoleArn"
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Layers": [
           {
             "Ref": "UtilLambdaLayer"
@@ -160,7 +160,7 @@
         "Role": {
           "Ref": "APILambdaRoleArn"
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Layers": [
           {
             "Ref": "UtilLambdaLayer"
@@ -196,7 +196,7 @@
         "Role": {
           "Ref": "APILambdaRoleArn"
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Layers": [
           {
             "Ref": "UtilLambdaLayer"
@@ -232,7 +232,7 @@
         "Role": {
           "Ref": "APILambdaRoleArn"
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Layers": [
           {
             "Ref": "UtilLambdaLayer"
@@ -268,7 +268,7 @@
         "Role": {
           "Ref": "APILambdaRoleArn"
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Layers": [
           {
             "Ref": "UtilLambdaLayer"
@@ -304,7 +304,7 @@
         "Role": {
           "Ref": "APILambdaRoleArn"
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Layers": [
           {
             "Ref": "UtilLambdaLayer"
@@ -1183,7 +1183,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60,
         "Tags": [
           {


### PR DESCRIPTION
CloudFormation templates in aws-sagemaker-guard have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.